### PR TITLE
Fix crash and UI issue

### DIFF
--- a/PreferencesForm.Designer.cs
+++ b/PreferencesForm.Designer.cs
@@ -54,20 +54,18 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(101, 11);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(76, 9);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(158, 17);
+            this.label1.Size = new System.Drawing.Size(121, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Web Page Screensaver";
             // 
             // llProjectLocationUrl
             // 
             this.llProjectLocationUrl.AutoSize = true;
-            this.llProjectLocationUrl.Location = new System.Drawing.Point(29, 31);
-            this.llProjectLocationUrl.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.llProjectLocationUrl.Location = new System.Drawing.Point(22, 25);
             this.llProjectLocationUrl.Name = "llProjectLocationUrl";
-            this.llProjectLocationUrl.Size = new System.Drawing.Size(293, 17);
+            this.llProjectLocationUrl.Size = new System.Drawing.Size(233, 13);
             this.llProjectLocationUrl.TabIndex = 1;
             this.llProjectLocationUrl.TabStop = true;
             this.llProjectLocationUrl.Text = "http://github.com/cwc/web-page-screensaver/";
@@ -77,10 +75,9 @@
             // 
             this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.okButton.Location = new System.Drawing.Point(127, 441);
-            this.okButton.Margin = new System.Windows.Forms.Padding(4);
+            this.okButton.Location = new System.Drawing.Point(115, 404);
             this.okButton.Name = "okButton";
-            this.okButton.Size = new System.Drawing.Size(100, 28);
+            this.okButton.Size = new System.Drawing.Size(75, 23);
             this.okButton.TabIndex = 4;
             this.okButton.Text = "OK";
             this.okButton.UseVisualStyleBackColor = true;
@@ -90,10 +87,9 @@
             // 
             this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancelButton.Location = new System.Drawing.Point(235, 441);
-            this.cancelButton.Margin = new System.Windows.Forms.Padding(4);
+            this.cancelButton.Location = new System.Drawing.Point(196, 404);
             this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(100, 28);
+            this.cancelButton.Size = new System.Drawing.Size(75, 23);
             this.cancelButton.TabIndex = 5;
             this.cancelButton.Text = "Cancel";
             this.cancelButton.UseVisualStyleBackColor = true;
@@ -105,10 +101,9 @@
             this.cbCloseOnActivity.AutoSize = true;
             this.cbCloseOnActivity.Checked = true;
             this.cbCloseOnActivity.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbCloseOnActivity.Location = new System.Drawing.Point(20, 411);
-            this.cbCloseOnActivity.Margin = new System.Windows.Forms.Padding(4);
+            this.cbCloseOnActivity.Location = new System.Drawing.Point(15, 381);
             this.cbCloseOnActivity.Name = "cbCloseOnActivity";
-            this.cbCloseOnActivity.Size = new System.Drawing.Size(200, 21);
+            this.cbCloseOnActivity.Size = new System.Drawing.Size(153, 17);
             this.cbCloseOnActivity.TabIndex = 6;
             this.cbCloseOnActivity.Text = "Close on mouse movement";
             this.cbCloseOnActivity.UseVisualStyleBackColor = true;
@@ -119,19 +114,21 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.screenTabControl.Controls.Add(this.screenTabPage1);
-            this.screenTabControl.Location = new System.Drawing.Point(20, 119);
+            this.screenTabControl.Location = new System.Drawing.Point(15, 97);
+            this.screenTabControl.Margin = new System.Windows.Forms.Padding(2);
             this.screenTabControl.Name = "screenTabControl";
             this.screenTabControl.SelectedIndex = 0;
-            this.screenTabControl.Size = new System.Drawing.Size(319, 271);
+            this.screenTabControl.Size = new System.Drawing.Size(261, 279);
             this.screenTabControl.TabIndex = 13;
             // 
             // screenTabPage1
             // 
             this.screenTabPage1.Controls.Add(this.prefsByScreenUserControl1);
-            this.screenTabPage1.Location = new System.Drawing.Point(4, 25);
+            this.screenTabPage1.Location = new System.Drawing.Point(4, 22);
+            this.screenTabPage1.Margin = new System.Windows.Forms.Padding(2);
             this.screenTabPage1.Name = "screenTabPage1";
-            this.screenTabPage1.Padding = new System.Windows.Forms.Padding(3);
-            this.screenTabPage1.Size = new System.Drawing.Size(311, 242);
+            this.screenTabPage1.Padding = new System.Windows.Forms.Padding(2);
+            this.screenTabPage1.Size = new System.Drawing.Size(253, 253);
             this.screenTabPage1.TabIndex = 0;
             this.screenTabPage1.Text = "Screen 1";
             this.screenTabPage1.UseVisualStyleBackColor = true;
@@ -143,17 +140,19 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.prefsByScreenUserControl1.BackColor = System.Drawing.Color.White;
             this.prefsByScreenUserControl1.Location = new System.Drawing.Point(0, 0);
+            this.prefsByScreenUserControl1.Margin = new System.Windows.Forms.Padding(0);
             this.prefsByScreenUserControl1.Name = "prefsByScreenUserControl1";
-            this.prefsByScreenUserControl1.Size = new System.Drawing.Size(312, 242);
+            this.prefsByScreenUserControl1.Size = new System.Drawing.Size(253, 254);
             this.prefsByScreenUserControl1.TabIndex = 21;
             // 
             // spanScreensButton
             // 
             this.spanScreensButton.AutoSize = true;
             this.spanScreensButton.Checked = true;
-            this.spanScreensButton.Location = new System.Drawing.Point(100, 10);
+            this.spanScreensButton.Location = new System.Drawing.Point(75, 8);
+            this.spanScreensButton.Margin = new System.Windows.Forms.Padding(2);
             this.spanScreensButton.Name = "spanScreensButton";
-            this.spanScreensButton.Size = new System.Drawing.Size(62, 21);
+            this.spanScreensButton.Size = new System.Drawing.Size(50, 17);
             this.spanScreensButton.TabIndex = 14;
             this.spanScreensButton.TabStop = true;
             this.spanScreensButton.Tag = "MultiScreenMode";
@@ -165,9 +164,10 @@
             // separateScreensButton
             // 
             this.separateScreensButton.AutoSize = true;
-            this.separateScreensButton.Location = new System.Drawing.Point(238, 10);
+            this.separateScreensButton.Location = new System.Drawing.Point(178, 8);
+            this.separateScreensButton.Margin = new System.Windows.Forms.Padding(2);
             this.separateScreensButton.Name = "separateScreensButton";
-            this.separateScreensButton.Size = new System.Drawing.Size(87, 21);
+            this.separateScreensButton.Size = new System.Drawing.Size(68, 17);
             this.separateScreensButton.TabIndex = 15;
             this.separateScreensButton.TabStop = true;
             this.separateScreensButton.Tag = "MultiScreenMode";
@@ -179,29 +179,28 @@
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(4, 12);
-            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label4.Location = new System.Drawing.Point(3, 10);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(84, 17);
+            this.label4.Size = new System.Drawing.Size(64, 13);
             this.label4.TabIndex = 16;
             this.label4.Text = "Multiscreen:";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(16, 97);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(12, 79);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(98, 17);
+            this.label2.Size = new System.Drawing.Size(76, 13);
             this.label2.TabIndex = 2;
             this.label2.Text = "Website URLs";
             // 
             // mirrorScreensButton
             // 
             this.mirrorScreensButton.AutoSize = true;
-            this.mirrorScreensButton.Location = new System.Drawing.Point(168, 10);
+            this.mirrorScreensButton.Location = new System.Drawing.Point(126, 8);
+            this.mirrorScreensButton.Margin = new System.Windows.Forms.Padding(2);
             this.mirrorScreensButton.Name = "mirrorScreensButton";
-            this.mirrorScreensButton.Size = new System.Drawing.Size(66, 21);
+            this.mirrorScreensButton.Size = new System.Drawing.Size(51, 17);
             this.mirrorScreensButton.TabIndex = 17;
             this.mirrorScreensButton.TabStop = true;
             this.mirrorScreensButton.Tag = "MultiScreenMode";
@@ -216,19 +215,21 @@
             this.multiScreenGroup.Controls.Add(this.mirrorScreensButton);
             this.multiScreenGroup.Controls.Add(this.spanScreensButton);
             this.multiScreenGroup.Controls.Add(this.separateScreensButton);
-            this.multiScreenGroup.Location = new System.Drawing.Point(20, 56);
+            this.multiScreenGroup.Location = new System.Drawing.Point(15, 46);
+            this.multiScreenGroup.Margin = new System.Windows.Forms.Padding(2);
             this.multiScreenGroup.Name = "multiScreenGroup";
-            this.multiScreenGroup.Size = new System.Drawing.Size(326, 34);
+            this.multiScreenGroup.Padding = new System.Windows.Forms.Padding(2);
+            this.multiScreenGroup.Size = new System.Drawing.Size(258, 28);
             this.multiScreenGroup.TabIndex = 18;
             this.multiScreenGroup.TabStop = false;
             // 
             // PreferencesForm
             // 
             this.AcceptButton = this.okButton;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.cancelButton;
-            this.ClientSize = new System.Drawing.Size(360, 478);
+            this.ClientSize = new System.Drawing.Size(292, 434);
             this.Controls.Add(this.multiScreenGroup);
             this.Controls.Add(this.screenTabControl);
             this.Controls.Add(this.cbCloseOnActivity);
@@ -237,10 +238,9 @@
             this.Controls.Add(this.label2);
             this.Controls.Add(this.llProjectLocationUrl);
             this.Controls.Add(this.label1);
-            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(378, 428);
+            this.MinimumSize = new System.Drawing.Size(288, 355);
             this.Name = "PreferencesForm";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;

--- a/PreferencesForm.cs
+++ b/PreferencesForm.cs
@@ -32,9 +32,9 @@ namespace pl.polidea.lab.Web_Page_Screensaver
             else
             {
                 multiScreenGroup.Enabled = true;
-                SetMultiScreenButtonFromMode();
-                ArrangeScreenTabs();
             }
+            SetMultiScreenButtonFromMode();
+            ArrangeScreenTabs();
         }
 
         private void LoadValuesForTab(int screenNum)

--- a/PreferencesForm.cs
+++ b/PreferencesForm.cs
@@ -14,7 +14,8 @@ namespace pl.polidea.lab.Web_Page_Screensaver
     {
         private PreferencesManager prefsManager = new PreferencesManager();
 
-        private List<PrefsByScreenUserControl> screenUserControls;
+        // Need to initialize in advance to prevent crashes when retrieving screenUserControls by index (LoadValuesForTab or ReadBackValuesFromUI)
+        private List<PrefsByScreenUserControl> screenUserControls = new List<PrefsByScreenUserControl>();
 
         public PreferencesForm()
         {
@@ -39,7 +40,7 @@ namespace pl.polidea.lab.Web_Page_Screensaver
         private void LoadValuesForTab(int screenNum)
         {
             var currentPrefsUserControl = screenUserControls[screenNum];
-            loadUrlsForTabToControl(screenNum, currentPrefsUserControl);
+            LoadUrlsForTabToControl(screenNum, currentPrefsUserControl);
             currentPrefsUserControl.nudRotationInterval.Value = prefsManager.GetRotationIntervalByScreen(screenNum);
             currentPrefsUserControl.cbRandomize.Checked = prefsManager.GetRandomizeFlagByScreen(screenNum);
         }
@@ -51,13 +52,17 @@ namespace pl.polidea.lab.Web_Page_Screensaver
                 case PreferencesManager.MultiScreenModeItem.Span:
                     RemoveExtraTabPages();
                     screenTabControl.TabPages[0].Text = "Composite Screen";
-                    screenUserControls = new List<PrefsByScreenUserControl>() { prefsByScreenUserControl1 };
+                    // Need to clear because we only expect one tab
+                    screenUserControls.Clear();
+                    screenUserControls.Add(prefsByScreenUserControl1);
                     LoadValuesForTab(0);
                     break;
                 case PreferencesManager.MultiScreenModeItem.Mirror:
                     RemoveExtraTabPages();
                     screenTabControl.TabPages[0].Text = "Each Screen";
-                    screenUserControls = new List<PrefsByScreenUserControl>() { prefsByScreenUserControl1 };
+                    // Need to clear because we only expect one tab
+                    screenUserControls.Clear();
+                    screenUserControls.Add(prefsByScreenUserControl1);
                     LoadValuesForTab(0);
                     break;
                 case PreferencesManager.MultiScreenModeItem.Separate:
@@ -75,13 +80,14 @@ namespace pl.polidea.lab.Web_Page_Screensaver
                                 var prefsByScreenUserControl = new PrefsByScreenUserControl
                                 {
                                     Name = string.Format("prefsByScreenUserControl{0}", i + 1),
-                                    Location = new Point(0, 0), //prefsByScreenUserControl1.Location,
+                                    Location = new Point(0, 0),
                                     Size = prefsByScreenUserControl1.Size,
                                     Anchor = prefsByScreenUserControl1.Anchor,
                                     BackColor = prefsByScreenUserControl1.BackColor
                                 };
                                 prefsByScreenUserControl.lvUrls.ContextMenuStrip =
                                     prefsByScreenUserControl1.ContextMenuStrip;
+                                // No need to clear because we are re-adding the missing tabs
                                 screenUserControls.Add(prefsByScreenUserControl);
                                 tabPage.Controls.Add(prefsByScreenUserControl);
                             }
@@ -89,8 +95,9 @@ namespace pl.polidea.lab.Web_Page_Screensaver
                         else if (screenTabControl.TabPages.Count == 1)
                         {
                             tabPage = screenTabControl.TabPages[0];
-                            screenUserControls =
-                                new List<PrefsByScreenUserControl>() { prefsByScreenUserControl1 };
+                            // Clearing before adding prevents a crash when going from Separate to Mirror and back to Separate
+                            screenUserControls.Clear();
+                            screenUserControls.Add(prefsByScreenUserControl1);
                         }
 
                         LoadValuesForTab(i);
@@ -127,7 +134,7 @@ namespace pl.polidea.lab.Web_Page_Screensaver
             }
         }
 
-        private void setMultiScreenModeFromButtonState()
+        private void SetMultiScreenModeFromButtonState()
         {
             if (spanScreensButton.Checked)
             {
@@ -145,7 +152,7 @@ namespace pl.polidea.lab.Web_Page_Screensaver
             prefsManager.ResetEffectiveScreensList();
         }
 
-        private void readBackValuesFromUI()
+        private void ReadBackValuesFromUI()
         {
             for (var i = 0; i < screenUserControls.Count; i++)
             {
@@ -160,7 +167,7 @@ namespace pl.polidea.lab.Web_Page_Screensaver
             }
         }
 
-        private void loadUrlsForTabToControl(int screenNum, PrefsByScreenUserControl currentPrefsUserControl)
+        private void LoadUrlsForTabToControl(int screenNum, PrefsByScreenUserControl currentPrefsUserControl)
         {
             currentPrefsUserControl.lvUrls.Items.Clear();
 
@@ -176,7 +183,7 @@ namespace pl.polidea.lab.Web_Page_Screensaver
         {
             if (DialogResult == DialogResult.OK)
             {
-                readBackValuesFromUI();
+                ReadBackValuesFromUI();
                 prefsManager.SavePreferences();
             }
 
@@ -200,8 +207,8 @@ namespace pl.polidea.lab.Web_Page_Screensaver
 
         private void anyMultiScreenModeButton_Click(object sender, EventArgs e)
         {
-            readBackValuesFromUI();
-            setMultiScreenModeFromButtonState();
+            ReadBackValuesFromUI();
+            SetMultiScreenModeFromButtonState();
             ArrangeScreenTabs();
         }
     }

--- a/PrefsByScreenUserControl.Designer.cs
+++ b/PrefsByScreenUserControl.Designer.cs
@@ -44,15 +44,14 @@
             // nudRotationInterval
             // 
             this.nudRotationInterval.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.nudRotationInterval.Location = new System.Drawing.Point(10, 275);
-            this.nudRotationInterval.Margin = new System.Windows.Forms.Padding(4);
+            this.nudRotationInterval.Location = new System.Drawing.Point(9, 220);
             this.nudRotationInterval.Maximum = new decimal(new int[] {
             999,
             0,
             0,
             0});
             this.nudRotationInterval.Name = "nudRotationInterval";
-            this.nudRotationInterval.Size = new System.Drawing.Size(53, 22);
+            this.nudRotationInterval.Size = new System.Drawing.Size(40, 20);
             this.nudRotationInterval.TabIndex = 6;
             this.nudRotationInterval.Value = new decimal(new int[] {
             30,
@@ -64,10 +63,9 @@
             // 
             this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(71, 277);
-            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label3.Location = new System.Drawing.Point(55, 222);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(188, 17);
+            this.label3.Size = new System.Drawing.Size(142, 13);
             this.label3.TabIndex = 7;
             this.label3.Text = "Seconds to display each site";
             // 
@@ -75,24 +73,24 @@
             // 
             this.cbRandomize.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.cbRandomize.AutoSize = true;
-            this.cbRandomize.Location = new System.Drawing.Point(10, 247);
-            this.cbRandomize.Margin = new System.Windows.Forms.Padding(4);
+            this.cbRandomize.Location = new System.Drawing.Point(10, 195);
             this.cbRandomize.Name = "cbRandomize";
-            this.cbRandomize.Size = new System.Drawing.Size(160, 21);
+            this.cbRandomize.Size = new System.Drawing.Size(121, 17);
             this.cbRandomize.TabIndex = 5;
             this.cbRandomize.Text = "Shuffle display order";
             this.cbRandomize.UseVisualStyleBackColor = true;
             // 
             // lvUrls
             // 
-            this.lvUrls.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-            | System.Windows.Forms.AnchorStyles.Left)
+            this.lvUrls.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.lvUrls.HideSelection = false;
             this.lvUrls.LabelEdit = true;
-            this.lvUrls.Location = new System.Drawing.Point(3, 3);
+            this.lvUrls.Location = new System.Drawing.Point(10, 10);
+            this.lvUrls.Margin = new System.Windows.Forms.Padding(2);
             this.lvUrls.Name = "lvUrls";
-            this.lvUrls.Size = new System.Drawing.Size(272, 187);
+            this.lvUrls.Size = new System.Drawing.Size(230, 150);
             this.lvUrls.TabIndex = 0;
             this.lvUrls.UseCompatibleStateImageBehavior = false;
             this.lvUrls.View = System.Windows.Forms.View.List;
@@ -100,10 +98,10 @@
             // addUrlButton
             // 
             this.addUrlButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.addUrlButton.Location = new System.Drawing.Point(3, 197);
-            this.addUrlButton.Margin = new System.Windows.Forms.Padding(4);
+            this.addUrlButton.Location = new System.Drawing.Point(9, 165);
+            this.addUrlButton.Margin = new System.Windows.Forms.Padding(0);
             this.addUrlButton.Name = "addUrlButton";
-            this.addUrlButton.Size = new System.Drawing.Size(77, 28);
+            this.addUrlButton.Size = new System.Drawing.Size(50, 25);
             this.addUrlButton.TabIndex = 11;
             this.addUrlButton.Text = "Add";
             this.addUrlButton.UseVisualStyleBackColor = true;
@@ -113,10 +111,10 @@
             // 
             this.upButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.upButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.upButton.Location = new System.Drawing.Point(251, 197);
+            this.upButton.Location = new System.Drawing.Point(190, 165);
             this.upButton.Margin = new System.Windows.Forms.Padding(0);
             this.upButton.Name = "upButton";
-            this.upButton.Size = new System.Drawing.Size(24, 28);
+            this.upButton.Size = new System.Drawing.Size(25, 25);
             this.upButton.TabIndex = 3;
             this.upButton.Text = "▲";
             this.urlButtonsTooltip.SetToolTip(this.upButton, "Move selected URLs up");
@@ -127,10 +125,10 @@
             // 
             this.downButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.downButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.downButton.Location = new System.Drawing.Point(251, 225);
+            this.downButton.Location = new System.Drawing.Point(215, 165);
             this.downButton.Margin = new System.Windows.Forms.Padding(0);
             this.downButton.Name = "downButton";
-            this.downButton.Size = new System.Drawing.Size(24, 28);
+            this.downButton.Size = new System.Drawing.Size(25, 25);
             this.downButton.TabIndex = 12;
             this.downButton.Text = "▼";
             this.urlButtonsTooltip.SetToolTip(this.downButton, "Move selected URLs down");
@@ -139,13 +137,12 @@
             // 
             // deleteButton
             // 
-            this.deleteButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.deleteButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.deleteButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.deleteButton.ForeColor = System.Drawing.Color.Red;
-            this.deleteButton.Location = new System.Drawing.Point(146, 197);
-            this.deleteButton.Margin = new System.Windows.Forms.Padding(0);
+            this.deleteButton.Location = new System.Drawing.Point(59, 165);
             this.deleteButton.Name = "deleteButton";
-            this.deleteButton.Size = new System.Drawing.Size(24, 28);
+            this.deleteButton.Size = new System.Drawing.Size(25, 25);
             this.deleteButton.TabIndex = 13;
             this.deleteButton.Text = "X";
             this.urlButtonsTooltip.SetToolTip(this.deleteButton, "DELETE selected URLs");
@@ -154,7 +151,7 @@
             // 
             // PrefsByScreenUserControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.White;
             this.Controls.Add(this.deleteButton);
@@ -165,8 +162,9 @@
             this.Controls.Add(this.cbRandomize);
             this.Controls.Add(this.lvUrls);
             this.Controls.Add(this.addUrlButton);
+            this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "PrefsByScreenUserControl";
-            this.Size = new System.Drawing.Size(279, 309);
+            this.Size = new System.Drawing.Size(250, 250);
             ((System.ComponentModel.ISupportInitialize)(this.nudRotationInterval)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();


### PR DESCRIPTION
PrefsByScreenUserControl does not have the correct size to show all the buttons at the same time when inside PreferencesForm.
I am facing this issue in a high resolution screen in Windows 10.
I fixed it by making sure the sizes are exact.
I also made sure that the sub-form would stay in the same place when switching tabs.

I also realized that when the user has multiple monitors, but then changes to 1 monitor, the preferences form shows the single screen tab list empty,
  instead of showing all the previously saved websites.
By moving two function calls inside PreferencesForm_Load outside the if/else, we ensure that switching from 1 to multi monitors, and back, will always show the expected list of pages in the expected tabs.